### PR TITLE
Improve matching of file markers

### DIFF
--- a/git-related
+++ b/git-related
@@ -208,7 +208,7 @@ class Commits
       when /^From (\h{40}) /, /^\0(\h{40})$/
         id = $1
         @main_commits[id] = true
-      when /^---\s+(\S+)/
+      when /^---\s+(\S+)$/
         source = $1 != '/dev/null' ? $1[2..-1] : nil
       when /^@@ -(\d+)(?:,(\d+))?/
         next unless source and id


### PR DESCRIPTION
Until now something like

```diff
---  DDL for Table TABLE_A
+--  DDL for Table TABLE_B
```

as part of a patch would have been matched by the regex that is expected
to match file markers only. For this reason that regex is improved a
little bit to avoid matching in those cases.